### PR TITLE
Eden-Loadout fix

### DIFF
--- a/W_FRAMEWORK/description.ext
+++ b/W_FRAMEWORK/description.ext
@@ -1,4 +1,4 @@
-w_framework_version = "v4.1.1";
+w_framework_version = "v4.1.2";
 
 enableDebugConsole = 1;
 respawn = 3;
@@ -22,3 +22,11 @@ respawn = 3;
 #ifdef MILSIM
 	medicSystem = "MILSIM";
 #endif
+
+class ACE_Settings {
+	#include "ACE_Settings.hpp"			// W_FRAMEWORK
+};
+
+class CfgFramework {
+	#include "CfgFramework.hpp"		// W_FRAMEWORK
+};

--- a/W_FRAMEWORK/packages/acre/functions/fn_acreRadios.sqf
+++ b/W_FRAMEWORK/packages/acre/functions/fn_acreRadios.sqf
@@ -1,7 +1,7 @@
 params [["_obj",objNull,[objNull]]];
 
 private _radios = ["ACRE_PRC343","ACRE_PRC148","ACRE_PRC152","ACRE_PRC117F","ACRE_PRC77"];
-private _whitelist = ["radio_whitelist",_radios,"ARRAY"] call FETT_framework_fnc_getSetting;
+private _whitelist = ["radios_whitelist",_radios,"ARRAY"] call FETT_framework_fnc_getSetting;
 _radios = _radios arrayIntersect _whitelist;
 
 {

--- a/W_FRAMEWORK/packages/acre/functions/fn_acreRadios.sqf
+++ b/W_FRAMEWORK/packages/acre/functions/fn_acreRadios.sqf
@@ -1,7 +1,7 @@
 params [["_obj",objNull,[objNull]]];
 
 private _radios = ["ACRE_PRC343","ACRE_PRC148","ACRE_PRC152","ACRE_PRC117F","ACRE_PRC77"];
-private _whitelist = ["radiowhitelist",_radios,"ARRAY"] call FETT_framework_fnc_getSetting;
+private _whitelist = ["radio_whitelist",_radios,"ARRAY"] call FETT_framework_fnc_getSetting;
 _radios = _radios arrayIntersect _whitelist;
 
 {

--- a/W_FRAMEWORK/packages/acre/functions/fn_acreRadios.sqf
+++ b/W_FRAMEWORK/packages/acre/functions/fn_acreRadios.sqf
@@ -1,7 +1,7 @@
 params [["_obj",objNull,[objNull]]];
 
 private _radios = ["ACRE_PRC343","ACRE_PRC148","ACRE_PRC152","ACRE_PRC117F","ACRE_PRC77"];
-private _whitelist = ["radios_whitelist",_radios,"ARRAY"] call FETT_framework_fnc_getSetting;
+private _whitelist = ["radiowhitelist",_radios,"ARRAY"] call FETT_framework_fnc_getSetting;
 _radios = _radios arrayIntersect _whitelist;
 
 {

--- a/W_FRAMEWORK/packages/loadouts/CfgFramework.hpp
+++ b/W_FRAMEWORK/packages/loadouts/CfgFramework.hpp
@@ -1,3 +1,9 @@
+class loadoutsFix {
+	code = "[] call FETT_framework_fnc_serverCreateHash";
+	server = 1;
+	preinit = 1;
+};
+
 class loadouts {
 	code = "[player] call FETT_framework_fnc_applyLoadout";
 	client = 1;

--- a/W_FRAMEWORK/packages/loadouts/CfgFunctions.hpp
+++ b/W_FRAMEWORK/packages/loadouts/CfgFunctions.hpp
@@ -3,6 +3,7 @@ class framework_loadouts {
     class main {
         file = "W_FRAMEWORK\packages\loadouts\functions";
         class applyLoadout {};
+        class serverCreateHash {};
     };
 };
 class framework_loadouts_api {

--- a/W_FRAMEWORK/packages/loadouts/functions/fn_applyLoadout.sqf
+++ b/W_FRAMEWORK/packages/loadouts/functions/fn_applyLoadout.sqf
@@ -17,7 +17,17 @@ if (isNull _obj) then {
     _obj = player;
 };
 params ["", ["_loadout", _obj getVariable ["loadout", ""], [""]], ["_side", _obj getVariable ["side", str (side _obj)], [""]]];
+
+if (isPlayer _obj && didJIP && {[W_frameworkLoadoutHash,name player] call CBA_fnc_hashHasKey}) then {
+    _loadout = [W_frameworkLoadoutHash,name player] call CBA_fnc_hashGet;
+};
+
 if (_loadout == "") exitWith {};
+
+if (isPlayer _obj && {!([W_frameworkLoadoutHash,name player] call CBA_fnc_hashHasKey)}) then {
+    W_frameworkLoadoutSync = [name player,_loadout];
+    publicVariableServer "W_frameworkLoadoutSync";
+};
 
 removeAllWeapons _obj;
 removeAllItems _obj;

--- a/W_FRAMEWORK/packages/loadouts/functions/fn_serverCreateHash.sqf
+++ b/W_FRAMEWORK/packages/loadouts/functions/fn_serverCreateHash.sqf
@@ -1,0 +1,10 @@
+W_frameworkLoadoutHash = [] call CBA_fnc_hashCreate;
+publicVariable "W_frameworkLoadoutHash";
+
+"W_frameworkLoadoutSync" addPublicVariableEventHandler {
+	params ["_varname","_data"];
+	_data params ["_playername","_loadoutClass"];
+
+	[W_frameworkLoadoutHash,_playername,_loadoutClass] call CBA_fnc_hashSet;
+	publicVariable "W_frameworkLoadoutHash";
+};


### PR DESCRIPTION
CBA-Hash hinzugefügt, der beim Start der Mission alle Loadoutklassen der Spieler speichert. Beim Jip können die Spieler dann anhand ihres Ingame-Namens ihre Klasse wieder erhalten. Dazu ist die Anwesenheit beim Durchstarten der Mission nötig bzw. der Spieler muss die Variable "loadout" gesetzt haben.